### PR TITLE
[Forwardport] Add sort order to user agent rules table headers

### DIFF
--- a/app/code/Magento/Backend/view/adminhtml/ui_component/design_config_form.xml
+++ b/app/code/Magento/Backend/view/adminhtml/ui_component/design_config_form.xml
@@ -92,7 +92,7 @@
                         </select>
                     </formElements>
                 </field>
-                <actionDelete template="Magento_Backend/dynamic-rows/cells/action-delete" sortOrder="50">
+                <actionDelete template="Magento_Backend/dynamic-rows/cells/action-delete">
                     <argument name="data" xsi:type="array">
                         <item name="config" xsi:type="array">
                             <item name="fit" xsi:type="boolean">false</item>


### PR DESCRIPTION
### Original Pull Request 
 https://github.com/magento/magento2/pull/16704
### Summary / Description
Only one column on the User Agent Rules table had a sort order. This was causing the content of the table rows to not match the content of the table.  I added the `sortOrder` attribute on the other two columns and this fixed the issue.

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. magento/magento2#16703 : User Agent Rules table headers do match content of rows

### Manual testing scenarios
1. Visit the page where you can edit a design configuration (change the theme). And review the table's headers.

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds on Travis CI are green)
